### PR TITLE
Silence a warning

### DIFF
--- a/src/flare/indexed.cljc
+++ b/src/flare/indexed.cljc
@@ -1,4 +1,5 @@
-(ns flare.indexed)
+(ns flare.indexed
+  (:require [clojure.string :as str]))
 
 (defn indexed-diff? [m]
   (and (map? m)
@@ -26,7 +27,7 @@
      :else (throw (ex-info "diff-or-coll must be vector or map" diff-or-coll)))))
 
 (defn join-with-newlines [coll]
-  (clojure.string/join "\n" coll))
+  (str/join "\n" coll))
 
 (defn report-indexed-diff-entry [[path diffs] report]
   (let [reports (flatten (map report diffs))


### PR DESCRIPTION
Using un-required namespaces causes a warning about undeclared names on newer Clojure(Script)s, this fix silences it.